### PR TITLE
Fix faulty height styling in TableSkeleton

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -166,13 +166,17 @@ const TableSkeleton = ({
 }: {
   rows: number;
   cells: number;
+  // rowHeight follows the format of Tailwind height
   rowHeight?: number;
 }) => {
   return Array.from({ length: rows }, (_, index) => (
     <TableRow key={index}>
       {Array.from({ length: cells }, (_, cellIndex) => (
         <TableCell key={cellIndex}>
-          <Skeleton className={`h-${rowHeight} w-full`} />
+          <Skeleton
+            className="w-full"
+            style={{ height: `${rowHeight / 4}rem` }}
+          />
         </TableCell>
       ))}
     </TableRow>


### PR DESCRIPTION
Using a template literal for Skeleton styling was leading to inconsistent height application. It seems to not be a thing you can do in Tailwind, so instead I applied style directly.